### PR TITLE
ユーザーテーブルとチームテーブルの関連付け

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -31,6 +31,7 @@ public class DemoApplication {
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
 						.allowedOrigins("http://localhost:3000")
+						.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 						.allowCredentials(true);
 			}
 		};

--- a/src/main/java/com/example/demo/bean/User.java
+++ b/src/main/java/com/example/demo/bean/User.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 @Data
 @Entity
@@ -22,8 +21,8 @@ public class User {
     @NotBlank(message = "{NotBlank.User.name}")
     private String name;
 
-    @Column(name= "team_id")
-    @NotNull(message = "{NotNull.User.team_id}")
-    private int team_id;
+    @ManyToOne
+    @JoinColumn(name="team_id")
+    private Team team;
 
 }

--- a/src/main/java/com/example/demo/repository/ReportRepository.java
+++ b/src/main/java/com/example/demo/repository/ReportRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ReportRepository extends JpaRepository<Report, Integer> {
 
     // 対象のチームID、年月のレポートを取得する
-    @Query("SELECT r FROM Report r WHERE r.user_id IN (SELECT u.id FROM User u  WHERE u.team_id = :teamId) " +
+    @Query("SELECT r FROM Report r WHERE r.user_id IN (SELECT u.id FROM User u  WHERE u.team.id = :teamId) " +
             "AND r.year = :thisYear AND r.month =:thisMonth")
     List<Report> findByTeamId(@Param("teamId") int teamId,@Param("thisYear") int thisYear,@Param("thisMonth") int thisMonth);
 }

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -10,6 +10,6 @@ import java.util.List;
 public interface UserRepository extends JpaRepository<User, Integer> {
 
     // 月報未登録者のIDを取得する
-    @Query("SELECT u.id FROM User u WHERE u.id NOT IN (SELECT r.user_id FROM Report r WHERE r.year = :thisYear AND r.month = :thisMonth) AND u.team_id = :teamId")
+    @Query("SELECT u.id FROM User u WHERE u.id NOT IN (SELECT r.user_id FROM Report r WHERE r.year = :thisYear AND r.month = :thisMonth) AND u.team.id = :teamId")
     List<Integer> checkSubmission(@Param("thisYear") int thisYear,@Param("thisMonth") int thisMonth, @Param("teamId") int teamId);
 }


### PR DESCRIPTION
ユーザー一覧画面にてチームの情報を表示する必要があったため、ユーザーを取得する際にチームIDからチームを取得するようにしました。

また、fix-cors-methodsから派生しているので先にそちらを取り込んでもらえると助かります。